### PR TITLE
Support SSL pinning

### DIFF
--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) SEGRequestFactory requestFactory;
 @property (nonatomic, readonly) NSMutableDictionary<NSString *, NSURLSession *> *sessionsByWriteKey;
 @property (nonatomic, readonly) NSURLSession *genericSession;
+@property (nonatomic, weak)  id<NSURLSessionDelegate> httpSessionDelegate;
 
 + (SEGRequestFactory)defaultRequestFactory;
 + (NSString *)authorizationHeader:(NSString *)writeKey;

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -51,7 +51,7 @@
             @"Authorization" : [@"Basic " stringByAppendingString:[[self class] authorizationHeader:writeKey]],
             @"User-Agent" : [NSString stringWithFormat:@"analytics-ios/%@", [SEGAnalytics version]],
         };
-        session = [NSURLSession sessionWithConfiguration:config];
+        session = [NSURLSession sessionWithConfiguration:config delegate:self.httpSessionDelegate delegateQueue:NULL];
         self.sessionsByWriteKey[writeKey] = session;
     }
     return session;

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -81,6 +81,7 @@ static BOOL GetAdTrackingEnabled()
         self.analytics = analytics;
         self.configuration = analytics.configuration;
         self.httpClient = httpClient;
+        self.httpClient.httpSessionDelegate = analytics.configuration.httpSessionDelegate;
         self.storage = storage;
         self.apiURL = [SEGMENT_API_BASE URLByAppendingPathComponent:@"import"];
         self.userId = [self getUserId];

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -166,4 +166,9 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
  */
 @property (nonatomic, strong, nonnull) NSDictionary<NSString*, NSString*>* payloadFilters;
 
+/**
+ * An optional delegate that handles NSURLSessionDelegate callbacks
+ */
+@property (nonatomic, strong, nullable) id<NSURLSessionDelegate> httpSessionDelegate;
+
 @end

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -47,6 +47,7 @@ class AnalyticsTests: QuickSpec {
       expect(analytics.configuration.shouldUseLocationServices) == false
       expect(analytics.configuration.enableAdvertisingTracking) == true
       expect(analytics.configuration.shouldUseBluetooth) == false
+      expect(analytics.configuration.httpSessionDelegate) == nil
       expect(analytics.getAnonymousId()).toNot(beNil())
     }
 


### PR DESCRIPTION

**What does this PR do?**
This PR provides scaffolding for client integrations to implement SSL pinning checks , if required

Client integrations can optionally pass in a NSURLSessionDelegate in the SEGAnalyticsConfiguration object.

If set, NSURLSessionDelegate callbacks are forwarded to the client code where SSL pinning checks can be implemented

**How should this be manually tested?**
AnalyticsTests has been modified to test httpSessionDelegate configuration

**Any background context you want to provide?**
currently Segment SDK does not provide SSL pinning support. we want to enable this

[Implementation Details on Tettra](https://app.tettra.co/teams/activehours/pages/certificate-pining-implementation-ios#certificate-pinning-for-segmentio-traffic)

**Questions:**
- Does the docs need an update?
yes

- Are there any security concerns?
no

- Do we need to update engineering / success?
yes